### PR TITLE
Bump Version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-sass-datepicker",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": ["js/bootstrap-sass-datepicker.js", "sass/datepicker.scss"],
   "ignore": [
   	"css",


### PR DESCRIPTION
Release next version because 1.3.6 is broken because it is missing $white.
